### PR TITLE
feat: add firebase auth state observer and sign out button

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,9 @@
 
             <section id="logged-in-view">
                 <div class="container">
+                    <nav class="logged-in-nav">
+                        <button id="sign-out-btn" class="sign-out-btn">Sign out</button>
+                    </nav>
                     <form class="term-form">
                         <div class="input-container">
                             <label for="term-input" class="textarea-label">

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function authSignInWithEmail() {
 
     signInWithEmailAndPassword(auth, email, password)
         .then((userCredential) => {
+            clearAuthFields()
             displayLoggedInView()
         })
         .catch((error) => {
@@ -65,6 +66,7 @@ function authCreateAcctWithEmail() {
 
     createUserWithEmailAndPassword(auth, email, password)
         .then((userCredential) => {
+            clearAuthFields()
             displayLoggedInView()
         })
         .catch((error) => {
@@ -99,4 +101,13 @@ function displayElement(element) {
 
 function hideElement(element) {
     element.style.display = "none"
+}
+
+function clearInputField(field) {
+    field.value = ""
+}
+
+function clearAuthFields() {
+    clearInputField(emailInputEL)
+    clearInputField(passwordInputEl)
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebas
 import { getAuth,
     createUserWithEmailAndPassword,
     signInWithEmailAndPassword,
-    signOut
+    signOut,
+    onAuthStateChanged
 } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js"
 
 
@@ -40,7 +41,14 @@ createAcctBtnEl.addEventListener("click", authCreateAcctWithEmail)
 signOutBtnEl.addEventListener("click", authSignOut)
 
 /* ===== MAIN JAVASCRIPT ===== */
-displayLoggedOutView()
+onAuthStateChanged(auth, (user) => {
+    if (user) {
+        displayLoggedInView()
+        const uid = user.uid;
+    } else {
+        displayLoggedOutView()
+    }
+})
 
 /* ===== FUNCTIONS ===== */
 /* ===== FUNCTIONS - FIREBASE - AUTHENTICATION */
@@ -51,7 +59,6 @@ function authSignInWithEmail() {
     signInWithEmailAndPassword(auth, email, password)
         .then((userCredential) => {
             clearAuthFields()
-            displayLoggedInView()
         })
         .catch((error) => {
             const errorCode = error.code
@@ -67,7 +74,6 @@ function authCreateAcctWithEmail() {
     createUserWithEmailAndPassword(auth, email, password)
         .then((userCredential) => {
             clearAuthFields()
-            displayLoggedInView()
         })
         .catch((error) => {
             const errorCode = error.code
@@ -78,7 +84,6 @@ function authCreateAcctWithEmail() {
 
 function authSignOut() {
     signOut(auth).then(() => {
-        displayLoggedOutView()
       }).catch((error) => {
         console.log(error)
       })

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js"
 import { getAuth,
     createUserWithEmailAndPassword,
-    signInWithEmailAndPassword
+    signInWithEmailAndPassword,
+    signOut
 } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js"
 
 
@@ -30,9 +31,13 @@ const passwordInputEl = document.getElementById("password-input")
 const signInBtnEl = document.getElementById("sign-in-btn")
 const createAcctBtnEl = document.getElementById("create-acct-btn")
 
+const signOutBtnEl = document.getElementById("sign-out-btn")
+
 /* ===== UI - EVENT LISTENERS ===== */
 signInBtnEl.addEventListener("click", authSignInWithEmail)
 createAcctBtnEl.addEventListener("click", authCreateAcctWithEmail)
+
+signOutBtnEl.addEventListener("click", authSignOut)
 
 /* ===== MAIN JAVASCRIPT ===== */
 displayLoggedOutView()
@@ -42,7 +47,7 @@ displayLoggedOutView()
 function authSignInWithEmail() {
     const email = emailInputEL.value
     const password = passwordInputEl.value
-    
+
     signInWithEmailAndPassword(auth, email, password)
         .then((userCredential) => {
             displayLoggedInView()
@@ -67,6 +72,14 @@ function authCreateAcctWithEmail() {
             const errorMessage = error.message
             console.error(`${errorCode}: ${errorMessage}`)
         });
+}
+
+function authSignOut() {
+    signOut(auth).then(() => {
+        displayLoggedOutView()
+      }).catch((error) => {
+        console.log(error)
+      })
 }
 
 /* ===== FUNCTIONS - UI FUNCTIONS ===== */

--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@ footer {
 
 /* ===== NAV LAYOUT STYLES ===== */
 
-nav {
+/* nav {
     display: flex;
     justify-content: space-between;
     padding: 0.6em 1em;
@@ -76,12 +76,16 @@ nav {
 .nav-link > a {
     text-decoration: none;
     color: #F5F5F5;
+} */
+
+.logged-in-nav {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 6em;
 }
 
-.nav-signin {
-    align-self: center;
-    text-decoration: none;
-    color: #F5F5F5;
+.sign-out-btn {
+    cursor: pointer;
 }
 
 /* ===== AUTHENTICATION PAGE STYLES ===== */


### PR DESCRIPTION
Add a temporary sign out button. Wrap the button in a nav.
Keep styles rudimentary as the sole purpose of these elements are to allow users to sign out.
Use default button styles but add a pointer cursor for a more obvious hover state. Create some space
between the term form and the temporary nav bar with a bottom margin.
Consider revamping said styles in future and creating a more composable general nav bar layout with React.

Add additional Firebase auth methods to enable a sign out feature and keep track of user authentication state.
Use the auth state observer to toggle the logged in or logged out views. Remove all other instances of these
functions responsible for controlling the display as they are now obsolete and overly repetitive.

Create callback functions to clear the authentication input fields whenever a user successfully creates a
new account or signs in to an existing one. Prior to this feature the input fields remained populated with
the entered email and password.